### PR TITLE
updated renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "30 days",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": true
+    },
+    {
+      "matchUpdateTypes": ["patch", "digest", "pin", "lockFileMaintenance"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
- updated `renovate.json` file so that Renovate only creates a PR after age is 30 days of more and only for minor dependency updates, not for patch.